### PR TITLE
Fix db entities

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,10 +64,14 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
-    implementation("androidx.room:room-runtime:2.5.0")
-    kapt("androidx.room:room-compiler:2.5.0")
-    implementation("androidx.room:room-ktx:2.5.0")
+    implementation("androidx.room:room-runtime:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
     implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
+    // Retrofit
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")

--- a/app/src/main/java/com/example/cs4520_twitter/data_layer/database/BabDAO.kt
+++ b/app/src/main/java/com/example/cs4520_twitter/data_layer/database/BabDAO.kt
@@ -22,7 +22,7 @@ interface BabDao {
      * Gets all babs associated with given user id
      */
     @Query("SELECT * FROM babs WHERE user_id = :userID")
-    suspend fun getAllFromUserByUserID(userID: String)
+    suspend fun getAllFromUserByUserID(userID: String): List<BabEntity?>
 
     @Query("DELETE FROM babs WHERE id = :babId")
     suspend fun deleteById(babId: String)

--- a/app/src/main/java/com/example/cs4520_twitter/data_layer/database/BabbleDatabase.kt
+++ b/app/src/main/java/com/example/cs4520_twitter/data_layer/database/BabbleDatabase.kt
@@ -14,7 +14,7 @@ import com.example.cs4520_twitter.utils.UserEntityTypeConverter
  * Provides singleton method of getting an instance handle
  * of the DB
  */
-@Database(entities = [UserEntity::class], version = 1)
+@Database(entities = [UserEntity::class, UserProfileEntity::class, BabEntity::class], version = 1)
 @TypeConverters(UserEntityTypeConverter::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun userDao(): UserDAO

--- a/app/src/main/java/com/example/cs4520_twitter/data_layer/database/UserDAO.kt
+++ b/app/src/main/java/com/example/cs4520_twitter/data_layer/database/UserDAO.kt
@@ -14,8 +14,8 @@ interface UserDAO {
      * Gets user object with given user id (UUID as string)
      */
     @Query("SELECT * FROM users WHERE id = :userID")
-    suspend fun getByUserID(userID: String)
+    suspend fun getByUserID(userID: String): UserEntity
 
     @Insert
-    suspend fun insert(userID: String)
+    suspend fun insert(user: UserEntity)
 }

--- a/app/src/main/java/com/example/cs4520_twitter/data_layer/database/UserProfile.kt
+++ b/app/src/main/java/com/example/cs4520_twitter/data_layer/database/UserProfile.kt
@@ -1,5 +1,6 @@
 package com.example.cs4520_twitter.data_layer.database
 
+import androidx.room.ColumnInfo
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/com/example/cs4520_twitter/utils/UserEntityTypeConverter.kt
+++ b/app/src/main/java/com/example/cs4520_twitter/utils/UserEntityTypeConverter.kt
@@ -1,6 +1,9 @@
 package com.example.cs4520_twitter.utils
 
 import androidx.room.TypeConverter
+import com.example.cs4520_twitter.data_layer.database.UserEntity
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import java.util.Date
 import java.util.UUID
 
@@ -8,6 +11,30 @@ import java.util.UUID
  * Type converter class used by RoomDB for entity fields of Date and UUID
  */
 class UserEntityTypeConverter {
+
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromString(value: String?): List<String>? {
+        val listType = object : TypeToken<List<String>>() {}.type
+        return gson.fromJson(value, listType)
+    }
+
+    @TypeConverter
+    fun listToString(list: List<String>?): String? {
+        return gson.toJson(list)
+    }
+
+    @TypeConverter
+    fun fromUserList(value: String?): List<UserEntity>? {
+        val listType = object : TypeToken<List<UserEntity>>() {}.type
+        return gson.fromJson(value, listType)
+    }
+
+    @TypeConverter
+    fun userListToString(list: List<UserEntity>?): String? {
+        return gson.toJson(list)
+    }
 
     @TypeConverter
     fun fromDate(value: Long?): Date? {
@@ -17,16 +44,6 @@ class UserEntityTypeConverter {
     @TypeConverter
     fun dateToLong(date: Date?): Long? {
         return date?.time
-    }
-
-    @TypeConverter
-    fun fromString(value: String?): UUID? {
-        return value?.let { UUID.fromString(it) }
-    }
-
-    @TypeConverter
-    fun uuidToString(uuid: UUID?): String? {
-        return uuid?.toString()
     }
 
 


### PR DESCRIPTION
Realized I just straight up didn't have return types on getters from DB OOPS :(. 

Added type converters for list of users, namely used in UserProfile and Bab to represent follower/following and liked by User lists respectively. 

Added retro fit as a dependency, as needed Gson to create the type converters.

Note:

I think I want to edit the tables to have foregin key relationships like a "real" db because things might get messy using these `Embedded` annotations, but should be good to move forward in prototyping. These changes should be able to be "retrofitted" later as all that would change is the queries. 